### PR TITLE
Adding missing class for checkbox TVs

### DIFF
--- a/manager/templates/default/resource/sections/tvs.tpl
+++ b/manager/templates/default/resource/sections/tvs.tpl
@@ -8,7 +8,7 @@
     <div id="modx-tv-tab{$category.id}" class="x-tab{if $category.hidden}-hidden{/if}" title="{$category.category}">
     {foreach from=$category.tvs item=tv name='tv'}
 {if $tv->type NEQ "hidden"}
-    <div class="modx-tv-type-{$tv->type} x-form-item x-tab-item {cycle values=",alt"} modx-tv{if $smarty.foreach.tv.first} tv-first{/if}{if $smarty.foreach.tv.last} tv-last{/if}" id="tv{$tv->id}-tr">
+    <div class="modx-tv-type-{$tv->type} {if $tv->type EQ "checkbox"} display-switch {/if} x-form-item x-tab-item {cycle values=",alt"} modx-tv{if $smarty.foreach.tv.first} tv-first{/if}{if $smarty.foreach.tv.last} tv-last{/if}" id="tv{$tv->id}-tr">
         <label for="tv{$tv->id}" class="x-form-item-label modx-tv-label">
             <div class="modx-tv-label-title">
                 {if $showCheckbox|default}<input type="checkbox" name="tv{$tv->id}-checkbox" class="modx-tv-checkbox" value="1" />{/if}


### PR DESCRIPTION

### What does it do?
Fixes regression bug when new display-switch class was introduced.

### Why is it needed?
Checkboxes were no longer being rendered as switches / toggles

